### PR TITLE
Split Docker compose stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Then, add the `docker.dev.env` file into project root.
 
 ## Bring up the Docker stack
 ```
-docker-compose -f docker-compose.dev.yml up
+docker-compose -f docker-compose.web.yml -f docker-compose.workers.yml up
 ```
 If there are no errors, you should be able to open Alpha Web app at http://localhost:50001
 
@@ -31,12 +31,12 @@ _Note: To persist the data, PostgreSQL container will mount its data volume into
 If you've added extra dependencies or applied changes that require
 containers be rebuilt, you can use this command:
 ```
-docker-compose -f docker-compose.dev.yml build --no-cache
+docker-compose -f docker-compose.web.yml -f docker-compose.workers.yml  build --no-cache
 ```
 
 Alternatively you can just delete images when bringing _down_ the stack.
 ```
-docker-compose -f docker-compose.dev.yml down --rmi all
+docker-compose -f docker-compose.web.yml -f docker-compose.workers.yml  down --rmi all
 ```
 
 # Running Locally
@@ -51,7 +51,7 @@ Package Dependencies:
  
 Install JS dependencies:
 ```
-cd src/public
+cd src/static
 npm i
 ```
 

--- a/docker-compose.web.yml
+++ b/docker-compose.web.yml
@@ -1,32 +1,5 @@
 version: '3'
 services:
-  celery-beat-tasks-cron:
-    build:
-      context: .
-      dockerfile: Dockerfile.worker
-    image: alpha:worker
-    command: celery -A src.tasks.cron beat
-    env_file:
-      - docker.dev.env
-    links:
-      - redis
-      - postgres
-    restart: always
-  celery-worker-tasks-cron:
-    build:
-      context: .
-      dockerfile: Dockerfile.worker
-    image: alpha:worker
-    command: celery worker -A src.tasks.cron -l info -c 1 -P solo
-    env_file:
-      - docker.dev.env
-    links:
-      - redis
-      - postgres
-    restart: always
-    depends_on:
-      - website
-    stop_grace_period: 3m30s
   website:
     build:
       context: .

--- a/docker-compose.workers.yml
+++ b/docker-compose.workers.yml
@@ -1,0 +1,29 @@
+version: '3'
+services:
+  celery-beat-tasks-cron:
+    build:
+      context: .
+      dockerfile: Dockerfile.worker
+    image: alpha:worker
+    command: celery -A src.tasks.cron beat
+    env_file:
+      - docker.dev.env
+    links:
+      - redis
+      - postgres
+    restart: always
+  celery-worker-tasks-cron:
+    build:
+      context: .
+      dockerfile: Dockerfile.worker
+    image: alpha:worker
+    command: celery worker -A src.tasks.cron -l info -c 1 -P solo
+    env_file:
+      - docker.dev.env
+    links:
+      - redis
+      - postgres
+    restart: always
+    depends_on:
+      - website
+    stop_grace_period: 3m30s


### PR DESCRIPTION
Compiling the ffmpeg and other worker related dependencies may take a long time. The split of compose stacks allows web developers and designers to quickly setup the website portion of the stack.