### PR TITLE
Add a template helper for video duration

### DIFF
--- a/src/views.py
+++ b/src/views.py
@@ -115,9 +115,9 @@ def edit_profile():
      group by channel.id
      having channel.user_id = :user_id;
     """
-    channels = db.session.query(Channel, func.count(Video.id))\
-        .join(Video)\
-        .group_by(Channel)\
+    channels = db.session.query(Channel, func.count(Video.id)) \
+        .join(Video) \
+        .group_by(Channel) \
         .having(Channel.user_id == current_user.id)
     return render_template(
         'edit_profile.html',


### PR DESCRIPTION
YouTube format seems to be the easiest to understand and its highly consistent - so I've implemented it.

Usage in templates:
```
{{ video.video_metadata.duration | toDuration }}
```