### PR TITLE
Make texts and video more compact so that CTAs are above the fold

### DIFF
--- a/src/static/css/post.css
+++ b/src/static/css/post.css
@@ -1,5 +1,5 @@
 .Post {
-  font-size: 17px !important;
+  font-size: 16px !important;
   line-height: 1.5;
 }
 

--- a/src/static/scss/components/_components.video-description.scss
+++ b/src/static/scss/components/_components.video-description.scss
@@ -35,22 +35,21 @@ $tweakpoint-video-description-header:           650px;
 }
 
     .c-video-description__title {
-        font-size: 26px;
+        font-size: 24px;
         font-weight: 700;
-        max-width: 30em;
-        margin-bottom: $spacing-unit-large;
+        margin-bottom: $spacing-unit + 5;
 
         @include mq(medium) {
-            font-size: 28px;
+            font-size: 26px;
         }
 
         @include mq(large) {
-            font-size: 32px;
+            font-size: 28px;
         }
     }
 
     .c-video-description__header {
-        margin-bottom: $spacing-unit-large;
+        margin-bottom: $spacing-unit + 5;
 
         @include mq($tweakpoint-video-description-header) {
             display: flex;

--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -66,7 +66,6 @@
                     {{ video.description | markdown }}
                 </div>
 
-                <br>
                 <a href="" id="description-show-more"
                      class="c-video-description__read-more"
                      style="display: none;">
@@ -117,7 +116,7 @@
         let resizePlayer = function () {
             // let the player take 80% of available screen height
             document.getElementById('embedded-player')
-                .setAttribute('height', String(window.innerHeight * 0.8));
+                .setAttribute('height', String(window.innerHeight * 0.75));
         };
         window.onload = function () {
             resizePlayer();
@@ -139,7 +138,7 @@
     <script type="application/javascript">
         // Show more logic (description)
         $(function () {
-            const visibleHeight = 100;
+            const visibleHeight = 140;
             let el = $('.js-video-description-text');
             if (el.height() > visibleHeight) {
                 el.css({height: visibleHeight + "px"});


### PR DESCRIPTION
- Fixed title not extending to the full width
- The title is now smaller so that longer titles would be one line height for most cases
- Video is now `75%` of window height. That, combined with the title being smaller ensures that CTAs are visible for large number of screens
- Made the truncated description text longer so that more text is initially visible