### PR TITLE
Increase video player height for laptop screens

### DIFF
--- a/src/static/scss/components/_components.video-player.scss
+++ b/src/static/scss/components/_components.video-player.scss
@@ -6,5 +6,5 @@
  * 1. Make sure there's room for video title and CTA buttons.
  */
 .c-video-player {
-    max-height: calc(100vh - 260px); /* [1] */
+    max-height: calc(100vh - 200px); /* [1] */
 }


### PR DESCRIPTION
<img width="1280" alt="screen shot 2018-03-31 at 6 10 08 pm" src="https://user-images.githubusercontent.com/3516903/38165116-d1a83d70-350e-11e8-9c8a-cc30ef5d182b.png">
The video doesn't look good on small screens (such as windows laptops).  



**Improvement:** 
Increase player height and remove description from view.