### PR TITLE
Add preview-on-hover to player seeking bar

### DIFF
--- a/src/templates/partials/player_js.html
+++ b/src/templates/partials/player_js.html
@@ -1,5 +1,6 @@
 <script src="{{ url_for('static', filename='node_modules/clappr/dist/clappr.min.js') }}"></script>
 <script src="{{ url_for('static', filename='node_modules/dash-shaka-playback/dist/dash-shaka-playback.min.js') }}"></script>
+<script src="//cdn.jsdelivr.net/clappr.thumbnails-plugin/latest/clappr-thumbnails-plugin.js"></script>
 <script type="application/javascript">
     let cdnUrl = "{{ cdn_url() }}";
     let manifestUrl = `${cdnUrl}/v1/{{ video_id }}/manifest.json`;
@@ -15,6 +16,30 @@
             console.log(err)
         });
     };
+
+    let thumbnailsSprite = function (manifest) {
+        if (manifest['timeline'] === 'undefined' || manifest['timeline'] === '') {
+            return []
+        }
+
+        let properties = manifest['timeline'].split('.')[0].split('_');
+        // skip properties[0] which is tilesheet_
+        let numThumbnails = properties[1];
+        let timeInterval = properties[2];
+        let tileWidth = properties[3];
+        let tileHeight = properties[4];
+
+        return ClapprThumbnailsPlugin.buildSpriteConfig(
+            `${cdnUrl}/v1/{{ video_id }}/${manifest.timeline}`,
+            numThumbnails,  // number of thumbnails
+            tileWidth, // thumbnail width
+            tileHeight, // thumbnail height
+            10, // number of tiles (columns) per row
+            timeInterval // time interval
+        );
+    };
+
+
     let loadPlayer = function (manifest) {
         let sources = [];
 
@@ -34,8 +59,14 @@
             height: window.innerHeight - 1,
             width: '100%',
             autoPlay: {{ autoPlay | int }},
+            scrubThumbnails: {
+                backdropHeight: 0,  // 100 gives a nice effect
+                spotlightHeight: 135,  // original is 135
+                thumbs: thumbnailsSprite(manifest)
+            },
             plugins: [
-                DashShakaPlayback
+                DashShakaPlayback,
+                ClapprThumbnailsPlugin
             ]
         });
         player.attachTo(document.getElementById("player-full"));
@@ -50,72 +81,3 @@
         player.resize({width: '100%', height: window.innerHeight - 1});
     }
 </script>
-
-{#<script src="//cdn.jsdelivr.net/clappr.thumbnails-plugin/latest/clappr-thumbnails-plugin.js"></script>#}
-{#<script src="{{ url_for('static', filename='js/clappr-playback-rate-plugin.min.js') }}"></script>#}
-{#<script>#}
-{#    var getContent = function () {#}
-{##}
-{#            var thumbnailsSprite = function () {#}
-{#                // first, we need to find the tilesheet#}
-{#                var fileNames = _.map(extractFiles(result['json_metadata']), function (o) {#}
-{#                    return o['Name'];#}
-{#                });#}
-{##}
-{#                var spriteFileName = _.first(#}
-{#                    _.filter(fileNames, function (filename) {#}
-{#                        return /tilesheet_.*\.png/.test(filename)#}
-{#                    })#}
-{#                );#}
-{##}
-{#                if (!spriteFileName) {#}
-{#                    return []#}
-{#                }#}
-{##}
-{#                var properties = _.tail(spriteFileName.split('.')[0].split('_'));#}
-{##}
-{#                var numThumbnails = properties[0];#}
-{#                var timeInterval = properties[1];#}
-{#                var tileWidth = properties[2];#}
-{#                var tileHeight = properties[3];#}
-{##}
-{#                return ClapprThumbnailsPlugin.buildSpriteConfig(#}
-{#                    linkBuilder(ipfs_hash, spriteFileName),#}
-{#                    numThumbnails,  // number of thumbnails#}
-{#                    tileWidth, // thumbnail width#}
-{#                    tileHeight, // thumbnail height#}
-{#                    10, // number of tiles (columns) per row#}
-{#                    timeInterval // time interval#}
-{#                );#}
-{#            };#}
-{##}
-{#            var player = new Clappr.Player({#}
-{#                source: linkBuilder(ipfs_hash, extractVideoFile(result['json_metadata'])),#}
-{#                poster: linkBuilder(ipfs_hash, "thumbnail_1.png"),#}
-{#                mute: false,#}
-{#                height: window.innerHeight - 20,#}
-{#                width: "100%",#}
-{#                autoPlay: {{ autoPlay }},#}
-{#                plugins: {#}
-{#                    core: [ClapprThumbnailsPlugin, PlaybackRatePlugin]#}
-{#                },#}
-{#                scrubThumbnails: {#}
-{#                    backdropHeight: 64,#}
-{#                    spotlightHeight: 84,#}
-{#                    thumbs: thumbnailsSprite()#}
-{#                },#}
-{#                playbackRateConfig: {#}
-{#                    defaultValue: '1.0',#}
-{#                    options: [#}
-{#                        {value: '0.5', label: '0.5x'},#}
-{#                        {value: '1.0', label: '1x'},#}
-{#                        {value: '1.25', label: '1.25x'},#}
-{#                        {value: '1.5', label: '1.5x'},#}
-{#                        {value: '2.0', label: '2x'}#}
-{#                    ]#}
-{#                }#}
-{#            });#}
-{##}
-{##}
-{#    };#}
-{#</script>#}


### PR DESCRIPTION
@nenadjelovac There are two options here:

1.) With timeline effect:
![screenshot from 2018-04-07 23-38-10](https://user-images.githubusercontent.com/3516903/38460593-45587d12-3abd-11e8-87ce-a0c1dfb3d4fa.png)

2.) A simple, YouTube like preview:
![screenshot from 2018-04-07 23-34-21](https://user-images.githubusercontent.com/3516903/38460596-506964d2-3abd-11e8-9dd9-68b2a290bf1b.png)

Feel free to play with both, and please let me know what you think is best.