### PR TITLE
Lock Ethereum dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,6 @@ lxml
 beautifulsoup4
 moviepy
 pytest
-eth-utils
-eth-account
-web3
+web3==4.1.0
+eth-utils==1.0.2
+eth-account==0.2.0a0


### PR DESCRIPTION
Lock to known stable versions, because these dependencies are often broken.