### PR TITLE
Fix a channel edit page bug

### DIFF
--- a/src/b_channel/__init__.py
+++ b/src/b_channel/__init__.py
@@ -93,7 +93,7 @@ def edit(channel_id):
     chan = db.session.query(Channel).filter_by(id=channel_id).one()
 
     form.name.data = form.name.data or chan.display_name
-    form.description.data = form.description.data or chan.description
+    form.description.data = form.description.data or chan.description or ''
 
     if form.validate_on_submit():
         display_name = form.name.data.strip()


### PR DESCRIPTION
If description is left empty, set it to empty string. Fixes sentry issue #541269956.