### PR TITLE
Add a mechanism for label extraction retry

### DIFF
--- a/src/tasks/analyze.py
+++ b/src/tasks/analyze.py
@@ -29,7 +29,7 @@ analyze.conf.update(
 @analyze.task(
     ignore_result=True,
     autoretry_for=(Exception,),
-    retry_kwargs={'max_retries': 3},
+    retry_kwargs={'max_retries': 5},
 )
 def extract_labels_from_video(video_id):
     """


### PR DESCRIPTION
Sometimes the label extraction will fail (due to many remote calls).
For those cases, we use a retry cron as a short-term fix.