### PR TITLE
Introduce medium thumbnail file size, nerf small

### DIFF
--- a/src/core/media.py
+++ b/src/core/media.py
@@ -81,7 +81,8 @@ def img_resize_multi(
     """
     sizes = sizes or [
         {'name': 'large', 'size': (1280, 720)},
-        {'name': 'small', 'size': (640, 360)},
+        {'name': 'medium', 'size': (640, 360)},
+        {'name': 'small', 'size': (480, 270)},
         {'name': 'tiny', 'size': (320, 180)},
         {'name': 'nano', 'size': (160, 90)},
     ]


### PR DESCRIPTION
Small images are too large to be used in grid view, and as such,
have been renamed to medium.

The new small image is 130k pixels vs 230k before (now medium).

_This change should improve grid view loading times, with a small visual fidelity loss._