### PR TITLE
Improved trending ranking formula

### DIFF
--- a/src/views.py
+++ b/src/views.py
@@ -170,7 +170,7 @@ def trending(page_num=0, items_per_page=18):
             Vote.video_id,
             func.sum((Vote.token_amount + Vote.delegated_amount) * Vote.weight)
                 .label('weight'))
-         .filter("created_at > (now() - interval '7 days')")
+         .filter("created_at > (now() - interval '5 days')")
          .group_by(Vote.video_id)
          .subquery())
 
@@ -181,7 +181,7 @@ def trending(page_num=0, items_per_page=18):
                  Video.analyzed_at.isnot(None),
                  Video.is_nsfw.is_(False),
                  'weight > 0')
-         .order_by(desc('weight'))
+         .order_by('((1.0 / ((now()::date - published_at::date) + 1)) * weight) DESC')
          .limit(limit)
          .offset(limit * page_num)
          .all())


### PR DESCRIPTION
In order to make the trending page more "fresh" (avoid hanging on to stale content), the following changes were implemented:
* Reduce range from past 7 days to past 5
* Introduce 1/x+1 video age penalty on vote weights

![screenshot from 2018-08-15 16-23-14](https://user-images.githubusercontent.com/3516903/44153098-8dc60114-a0a7-11e8-93c4-f467e79697e1.png)

![screenshot from 2018-08-15 16-24-09](https://user-images.githubusercontent.com/3516903/44153135-a8d691a8-a0a7-11e8-8091-6bead65f2631.png)
