### PR TITLE
Revert and force Semantic version to 2.3.1 because of scrolling issue

### DIFF
--- a/src/static/package-lock.json
+++ b/src/static/package-lock.json
@@ -7760,9 +7760,9 @@
       }
     },
     "semantic-ui-css": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/semantic-ui-css/-/semantic-ui-css-2.3.3.tgz",
-      "integrity": "sha512-/UDs+a07LdxmYgVNqkbW9x5Gil1Dt4HnVq4LrHKKUAD/DUDh0fnwmCxbQFyKKD+YsVDQWFqftyVbYKlClBFLDw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/semantic-ui-css/-/semantic-ui-css-2.3.1.tgz",
+      "integrity": "sha512-8M2OkoKZHfEnNUYB4Ha8q+tTAWN/g17X2l6HUg6n3DP4QDJLQl1xyhnRvM9UhJpsRvkRqgWgQLbRA6cl7Ep2dw==",
       "requires": {
         "jquery": "2.2.4"
       }

--- a/src/static/package.json
+++ b/src/static/package.json
@@ -26,7 +26,7 @@
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0",
     "sass-mq": "^4.0.2",
-    "semantic-ui-css": "^2.3.2",
+    "semantic-ui-css": "2.3.1",
     "tai-password-strength": "^1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Scrolling on mobile is broken in newest version of Semantic, so I reverted it to 2.3.1 and fixed that version. Related issue: https://github.com/Semantic-Org/Semantic-UI/issues/6449

I checked latest 2 releases and there shouldn't be any breaking changes so its safe to revert to older version.