### PR TITLE
Raise gas price buffer

### DIFF
--- a/src/api/gas_price.py
+++ b/src/api/gas_price.py
@@ -8,4 +8,4 @@ from ..core.eth import gas_price
 class GasPriceApi(Resource):
     def get(self):
         price = gas_price()
-        return {'normal': price - 4, 'fast': price}
+        return {'normal': price, 'fast': price + 10}


### PR DESCRIPTION
Users have to pay higher gas price on average, but it avoids stuck transactions when ETH is clogged.