### PR TITLE
Max password length set to 64 characters

### DIFF
--- a/src/static/js/components/unlockModal/index.js
+++ b/src/static/js/components/unlockModal/index.js
@@ -104,7 +104,7 @@ export default class UnlockModal extends Component {
               <div className='ui form'>
                 <div className="field">
                   <label>Wallet password</label>
-                  <input ref={(ref) => this.passwordInput = ref} type='password' value={this.state.password} onKeyDown={this.onKeyDown} onChange={(e) => this.setState({ password: e.target.value })}/>
+                  <input ref={(ref) => this.passwordInput = ref} type='password' value={this.state.password} onKeyDown={this.onKeyDown} onChange={(e) => this.setState({ password: e.target.value })} maxLength={64} />
                 </div>
               </div>
             )}

--- a/src/static/js/components/walletPage/generate/step3/index.js
+++ b/src/static/js/components/walletPage/generate/step3/index.js
@@ -12,7 +12,7 @@ export default class GeneratorStep3 extends Component {
   encryptWallet = () => {
     const { wallet, changeStep } = this.props;
 
-    if (!this.state.password) {
+    if ((!this.state.password) || (this.state.password.length > 64)) {
       this.passwordInput.focus();
       this.passwordInput.parentElement.classList.add('error');
       return false;
@@ -42,7 +42,7 @@ export default class GeneratorStep3 extends Component {
               <div className="eight wide column">
                 <div className="field">
                   <label>Encryption password</label>
-                  <input ref={(ref) => this.passwordInput = ref} type="password" placeholder="Password" value={this.state.password} onChange={(e) => this.setState({ password: e.target.value })} autoComplete="new-password" />
+                  <input ref={(ref) => this.passwordInput = ref} type="password" placeholder="Password" value={this.state.password} onChange={(e) => this.setState({ password: e.target.value })} autoComplete="new-password" maxLength={64} />
                   <div className="ui pointing label">
                     If you forget this password, only way to recover is using mnemonic words
                   </div>


### PR DESCRIPTION
If supplied password is larger than 64 characters, encryption library throws an error. Quick workaround is to limit max length to 64 until I figure if its possible to have bigger passwords.