### PR TITLE
Check if receipt exists before trying to access status property

### DIFF
--- a/src/static/js/api/transaction.js
+++ b/src/static/js/api/transaction.js
@@ -16,7 +16,7 @@ export async function transactionWait(baseUrl, { txn_id }) {
 
   const receipt = await provider.getTransactionReceipt(txn_id);
 
-  if (receipt.status === 0) {
+  if (receipt && receipt.status === 0) {
     throw new Error('Transaction execution has failed.');
   }
 


### PR DESCRIPTION
This should hopefully fix the issue with "Cannot read property 'status' of null".

Looks like mainnet fetching transaction receipt immediately after the transaction is mined might fail, so we should just silently fail instead of showing an error.