### PR TITLE
Implement a possibility to unlock a wallet using mnemonic

### DIFF
--- a/src/static/js/components/unlockModal/index.js
+++ b/src/static/js/components/unlockModal/index.js
@@ -1,4 +1,5 @@
 import React, { Component} from "react";
+import { Link } from "react-router-dom";
 import { connect } from "react-redux";
 import { providers, utils, Contract, Wallet } from 'ethers';
 
@@ -85,7 +86,7 @@ export default class UnlockModal extends Component {
   }
 
   render() {
-    const { unlockModalClose } = this.props;
+    const { wallet, unlockModalClose } = this.props;
 
     return (
       <Portal container='react-modal'>
@@ -106,6 +107,7 @@ export default class UnlockModal extends Component {
                   <label>Wallet password</label>
                   <input ref={(ref) => this.passwordInput = ref} type='password' value={this.state.password} onKeyDown={this.onKeyDown} onChange={(e) => this.setState({ password: e.target.value })} maxLength={64} />
                 </div>
+                <Link to={`/wallet/${wallet.address}/recover`} onClick={() => unlockModalClose()}>Forgot password?</Link>
               </div>
             )}
 

--- a/src/static/js/components/walletPage/index.js
+++ b/src/static/js/components/walletPage/index.js
@@ -6,6 +6,7 @@ import Portal from '../portal';
 import WalletHome from './home';
 import WalletSingle from './single';
 import WalletGenerator from './generate';
+import WalletRecover from './recover';
 
 export default class WalletPage extends Component {
   render() {
@@ -14,6 +15,7 @@ export default class WalletPage extends Component {
         <Switch>
           <Route exact path='/wallet' component={WalletHome} />
           <Route exact path='/wallet/generate' component={WalletGenerator} />
+          <Route exact path='/wallet/:wallet/recover' component={WalletRecover} />
           <Route path='/wallet/:wallet' component={WalletSingle} />
         </Switch>
       </Portal>

--- a/src/static/js/components/walletPage/recover/index.js
+++ b/src/static/js/components/walletPage/recover/index.js
@@ -1,0 +1,66 @@
+import React, { Component} from "react";
+import { connect } from "react-redux";
+import { Wallet } from 'ethers';
+import { unlockWallet } from '../../../actions';
+
+@connect((state, props) => ({
+  wallet: state.wallet.address === props.match.params.wallet && state.wallet,
+}), (dispatch) => ({
+  unlockWallet: (address, privateKey) => dispatch(unlockWallet(address, privateKey))
+}))
+export default class WalletRecover extends Component {
+  state = {
+    mnemonic: '',
+    error: false,
+    errorText: ''
+  }
+
+  checkMnemonic = () => {
+    const { wallet, unlockWallet, history } = this.props;
+
+    this.setState({ error: false });
+    try {
+      const newWallet = Wallet.fromMnemonic(this.state.mnemonic);
+
+      if (newWallet.address !== wallet.address) {
+        this.setState({ error: true, errorText: 'Mnemonic doesn\'t match this wallet'});
+        return false;
+      }
+
+      unlockWallet(newWallet.address, newWallet.privateKey);
+      history.push(`/wallet/${newWallet.address}`);
+
+    } catch (e) {
+      this.setState({ error: true, errorText: 'Invalid mnemonic'});
+    }
+  }
+
+  render() {
+    const { wallet } = this.props;
+
+    return (
+      <div className='ui container'>
+        <h2 className="ui center aligned icon dividing header">
+          {wallet.decrypted && <i className="circular lock open icon"></i>}
+          {!wallet.decrypted && <i className="circular lock icon"></i>}
+          Wallet recovery
+          <div className="sub header">{wallet.address}</div>
+        </h2>
+
+        <div className='ui padded container'>
+          <div className='ui message'>
+            Recover wallet using 12 word mnemonic
+          </div>
+
+          <div className={`ui fluid action input ${this.state.error && 'error'}`}>
+            <input type="text" placeholder="Your mnemonic here ..." value={this.state.mnemonic} onChange={(e) => this.setState({ mnemonic: e.target.value })} />
+            <div className="ui button" onClick={this.checkMnemonic}>Check</div>
+          </div>
+          {this.state.error && (
+            <div className="ui pointing red label">{this.state.errorText}</div>
+          )}
+        </div>
+      </div>
+    )
+  }
+}

--- a/src/views.py
+++ b/src/views.py
@@ -254,6 +254,7 @@ def about():
 @app.route('/wallet/generate')
 @app.route('/wallet')
 @app.route('/wallet/<string:address>')
+@app.route('/wallet/<string:address>/recover')
 @app.route('/wallet/<string:address>/withdraw/<string:withdraw_type>')
 @login_required
 def wallet(address='', withdraw_type=''):


### PR DESCRIPTION
Work in progress, but it still allows users with forgotten password to unlock their wallets.
This change only adds a possibility to unlock a wallet using mnemonic.
![recover](https://user-images.githubusercontent.com/933433/45602000-73399300-ba16-11e8-98e5-43d4acbc6341.gif)


It doesn't prompt user to type new password to update wallet until we figure out what is the safest way to do that with guarantee that user that has access to wallet has requested a change.
I'm thinking that it should be enough to sign some data using private key which will act as a guarantee for backend that user has full access to wallet (something like sign typed data for voting) ?