### PR TITLE
Add prod config to fingerprint static files when building a project

### DIFF
--- a/src/static/package.json
+++ b/src/static/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "scripts": {
     "start": "webpack-dev-server --mode development",
-    "build": "webpack --mode production"
+    "clear": "rimraf ./dist",
+    "build": "npm run clear && webpack --mode production --config webpack.config.prod.js"
   },
   "dependencies": {
     "accoutrement-color": "^2.3.1",
@@ -43,6 +44,7 @@
     "babel-preset-stage-0": "^6.24.1",
     "css-loader": "^0.28.11",
     "redux-devtools": "^3.4.1",
+    "rimraf": "^2.6.2",
     "style-loader": "^0.21.0",
     "svg-url-loader": "^2.3.2",
     "webpack": "^4.12.0",

--- a/src/static/webpack.config.prod.js
+++ b/src/static/webpack.config.prod.js
@@ -1,0 +1,9 @@
+const baseConfig = require('./webpack.config');
+const path = require("path");
+
+module.exports = Object.assign(baseConfig, {
+  output: {
+    path: path.resolve(__dirname, "dist/"),
+    filename: "[name]-[hash].js"
+  },
+})


### PR DESCRIPTION
Partially fixes #273 by generating files with fingerprint/hash