### PR TITLE
Give search inputs a name

### DIFF
--- a/src/static/js/components/searchInput/index.js
+++ b/src/static/js/components/searchInput/index.js
@@ -97,6 +97,7 @@ export default class SearchInput extends Component {
           <input
             className="c-header__search__input"
             placeholder={this.state.selected === -1 ? 'Search' : search.data[this.state.selected].display_name}
+            name="search_input"
             value={this.state.selected === -1 ? this.state.searchText : ''}
             onChange={(e) => this.setState({ searchText: e.target.value })}
             onBlur={this.onBlur}

--- a/src/templates/partials/main_menu.html
+++ b/src/templates/partials/main_menu.html
@@ -19,7 +19,7 @@
         </a>
         <div id="search-box" class="ui action icon input js-search-box">
           <button class="ui button js-search-button">{% include 'atoms/icon-search.html' %}</button>
-          <input class="c-header__search__input js-search-input" placeholder="Search" value="{{ query }}">
+          <input class="c-header__search__input js-search-input" name="search_input" placeholder="Search" value="{{ query }}">
         </div>
         <div id="react-search"></div>
       </div>


### PR DESCRIPTION
If inputs have a "search" in name, password managers *should* ignore it