### PR TITLE
Don't check if voted before wallet loads

### DIFF
--- a/src/static/js/components/videoPage/vote/viewly/index.js
+++ b/src/static/js/components/videoPage/vote/viewly/index.js
@@ -19,8 +19,17 @@ export default class VoteViewly extends Component {
   componentDidMount () {
     const { isVoted, videoId, wallet } = this.props;
 
-    isVoted(videoId, wallet.address);
+    wallet.address && isVoted(videoId, wallet.address);
   }
+
+  componentDidUpdate(prevProps) {
+    const { isVoted, videoId, wallet } = this.props;
+
+    if (wallet.address !== prevProps.wallet.address) {
+      wallet.address && isVoted(videoId, wallet.address);
+    }
+  }
+
 
   voteClick = async () => {
     const { wallet, unlockModalOpen, videoVote, videoId } = this.props;


### PR DESCRIPTION
This should fix the vote persistance, because in some situations vote check was triggered before wallet was loaded in state.