### PR TITLE
Remove no search results message

### DIFF
--- a/src/static/js/components/searchInput/index.js
+++ b/src/static/js/components/searchInput/index.js
@@ -106,18 +106,11 @@ export default class SearchInput extends Component {
           />
         </div>
 
-        {this.state.dropdownOpen && (
+        {this.state.dropdownOpen && search.data.length !== 0 && (
           <div className="c-search-dropdown">
 
             <h3 class="c-search-dropdown__heading">Channels</h3>
             <ul className="c-search-dropdown__list">
-
-              {search.data.length === 0 && !isLoading && (
-                <li className="c-search-dropdown__no-results">
-                  <img className="c-search-dropdown__no-results__img" src="/static/img/no-results.svg" alt="" />
-                  <p>No channels found</p>
-                </li>
-              )}
 
               {search.data.map((item, idx) => (
                 <li>

--- a/src/static/scss/utilities/_utilities.shame.scss
+++ b/src/static/scss/utilities/_utilities.shame.scss
@@ -514,17 +514,3 @@ body {
             }
         }
     }
-
-    .c-search-dropdown__no-results[class] {
-        padding: $spacing-unit-tiny !important;
-        text-align: center;
-
-        p {
-            margin-bottom: 0;
-        }
-    }
-
-    .c-search-dropdown__no-results__img {
-        margin-bottom: $spacing-unit-small;
-        width: 80px;
-    }


### PR DESCRIPTION
@turshija @Netherdrake as discussed in https://github.com/Viewly/alpha-2/pull/297, here's the search autocomplete without the "no results" message for improved UX.