### PR TITLE
Fix text overlap on mobile

### DIFF
--- a/src/static/scss/components/_components.hero-about.scss
+++ b/src/static/scss/components/_components.hero-about.scss
@@ -86,7 +86,7 @@
             background-image: url('../../img/about-viewly-graphic.png');
             background-position: center center;
             background-repeat: no-repeat;
-            background-size: 80%;
+            background-size: 70%;
             content: '';
             height: 223px;
             transform: translate(-50%, -50%) translateX(-20px);
@@ -95,6 +95,10 @@
             top: 50%;
             left: 50%;
             z-index: 100;
+
+            @include mq(large) {
+                background-size: 80%;
+            }
 
             @include mq(extralarge) {
                 background-size: 100%;


### PR DESCRIPTION
There was some overlap on small screens so the title above the main one was a bit cut off.