### PR TITLE
Fix react search width

### DIFF
--- a/src/static/js/components/searchInput/index.js
+++ b/src/static/js/components/searchInput/index.js
@@ -21,7 +21,9 @@ export default class SearchInput extends Component {
 
   componentDidMount() {
     const elem = document.getElementById('search-box');
+    const reactSearchContainer = document.getElementById('react-search');
     elem && elem.parentNode.removeChild(elem);
+    reactSearchContainer.classList.add('u-1/1');
   }
 
   componentDidUpdate(prevProps, prevState) {


### PR DESCRIPTION
For some reason (that I haven't fully figured out yet) when react search is loaded it has the wrong width. This breaks the search width on mobile/tablet viewports since it's not 100% wide as it's supposed to be. Also, there's a jump on desktop when it removes the original search html and injects react's search html.

Here I'm adding a fix that seems to be working. I think we should also refactor search html code a bit when we have the time, so this fix is good enough for me at the moment.