### PR TITLE
Fix faq question font size on phones

### DIFF
--- a/src/static/scss/utilities/_utilities.shame.scss
+++ b/src/static/scss/utilities/_utilities.shame.scss
@@ -240,8 +240,14 @@ body {
             text-transform: uppercase;
         }
 
+        /**
+         * 1. Make the question same size as the text for better consistency,
+         *    since Semantic UI css is applying some questionable styles which
+         *    make the font size too small on phones.
+         */
         .c-faq__question {
             color: #5b5e6d;
+            font-size: inherit; /* [1] */
             font-weight: 700;
             margin-bottom: $spacing-unit-small;
 


### PR DESCRIPTION
Semantic UI css is applying some questionable styles for headings, which in this case make the font size too small on phones. This PR fixes that.