### PR TITLE
Remove autofill on search input

### DIFF
--- a/src/static/js/components/searchInput/index.js
+++ b/src/static/js/components/searchInput/index.js
@@ -114,6 +114,7 @@ export default class SearchInput extends Component {
             onBlur={this.onBlur}
             onFocus={this.onFocus}
             onKeyDown={this.onKeyDown}
+            autocomplete="off"
           />
         </div>
 
@@ -125,11 +126,11 @@ export default class SearchInput extends Component {
             <ul className="c-search-dropdown__list">
               {search.data.map((item, idx) => (
                 <SearchItem
-                  key={`search-${item.channel_id}`} 
-                  channel_id={item.channel_id} 
-                  url={item.channel_url} 
-                  selected={this.state.selected === idx} 
-                  avatar={item.avatar_url} 
+                  key={`search-${item.channel_id}`}
+                  channel_id={item.channel_id}
+                  url={item.channel_url}
+                  selected={this.state.selected === idx}
+                  avatar={item.avatar_url}
                   name={item.display_name} />
               ))}
             </ul>


### PR DESCRIPTION
When chrome remembers your previous choices the UX becomes really shitty:

- It is visually bad after search drop down has been shown
- It breaks keyboard usage (up/down) because up/down then work with native autocomplete

See it in action here https://i.gyazo.com/842843e9b0538395a53a810584372b52.mp4.

This PR fixes it.