### PR TITLE
Force py-redis version > 3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ python-slugify
 boto3
 maya
 delegator.py
+redis>=3.2.0
 celery[redis,auth]
 Pillow
 psycopg2-binary


### PR DESCRIPTION
Due to bugs in celery.